### PR TITLE
feat: [CI-15754]: support pipeline labels, as per harness v1 spec

### DIFF
--- a/dist/go/pipeline.go
+++ b/dist/go/pipeline.go
@@ -21,6 +21,7 @@ type Pipeline struct {
 	Stages  []*Stage          `json:"stages,omitempty"`
 	Inputs  map[string]*Input `json:"inputs,omitempty"`
 	Options *Default          `json:"options,omitempty"`
+	Labels  map[string]string `json:"labels,omitempty"`
 }
 
 type PipelineV1 struct {

--- a/dist/schema.json
+++ b/dist/schema.json
@@ -167,6 +167,12 @@
                 "options": {
                     "$ref": "#/definitions/Default",
                     "description": "Options defines global configuration options."
+                },
+                "labels": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
                 }
             },
             "required": [

--- a/schema/pipeline.yaml
+++ b/schema/pipeline.yaml
@@ -19,6 +19,11 @@ properties:
     $ref: ./default.yaml
     description: Options defines global configuration options.
 
+  labels:
+    type: object
+    additionalProperties:
+      type: string
+
 required:
   - stages
 


### PR DESCRIPTION
This PR adds the `labels` field to the pipeline object, as per the Harness v1 spec found here,
https://github.com/harness/harness-schema/blob/main/v1/pipeline/pipeline_spec.yaml

I'm not sure if the Drone spec should match the Harness spec or not but we have a use-case in go-convert where we need a labels field to pass along some pipeline tags into the downgrader. 